### PR TITLE
Change AccidentalTypes

### DIFF
--- a/notes/build_notes_objects.py
+++ b/notes/build_notes_objects.py
@@ -62,7 +62,7 @@ def detect_accidentals(staff: Staff, threshold: float) -> List[Accidental]:
 
     for i in range(len(matched_accidentals)):
         current: Accidental = matched_accidentals[i]
-        if current.type in [AccidentalTypes.FLAT_DOUBLE, AccidentalTypes.SHARP_DOUBLE, AccidentalTypes.NATURAL]:
+        if current.acc_type in [AccidentalTypes.FLAT_DOUBLE, AccidentalTypes.SHARP_DOUBLE, AccidentalTypes.NATURAL]:
             # It is either a double flat, double sharp or a natural (and must therefore be local)
             current.set_is_local(True)
             continue
@@ -71,7 +71,7 @@ def detect_accidentals(staff: Staff, threshold: float) -> List[Accidental]:
         if previous:
             if previous.x - current.x < (staff.dist * 1.5) \
                     and (previous.y - current.y) > (staff.dist * 0.5) \
-                    and previous.type is current.type:
+                    and previous.acc_type is current.acc_type:
                 # A group of accidentals that are of the same type, sufficiently close and not on the same line
                 previous.set_is_local(False)
                 current.set_is_local(False)

--- a/notes/note_objects.py
+++ b/notes/note_objects.py
@@ -122,8 +122,14 @@ class Flag:
 
 
 class Rest:
-    duration_dict = {'full_rest': 4, 'half_rest': 2, 'fourth_rest': 1, 'eighth_rest': 1 / 2, 'sixteenth_rest': 1 / 4,
-                     'semidemiquaver_rest': 1 / 8}
+    duration_dict = {
+        'full_rest': 4,
+        'half_rest': 2,
+        'fourth_rest': 1,
+        'eighth_rest': 1 / 2,
+        'sixteenth_rest': 1 / 4,
+        'semidemiquaver_rest': 1 / 8
+    }
 
     def __init__(self, x, y, template, staff):
         self.type = 'rest'
@@ -137,23 +143,35 @@ class Rest:
         self.duration = int(self.duration_dict[self.name] * staff.divisions)
 
 
-class Accidental:
-    pitch_change_dict = {
-        'double_flat': -1,
-        'flat': -1 / 2,
-        'natural': 0,
-        'sharp': 1 / 2,
-        'double_sharp': 1
-    }
+@unique
+class AccidentalTypes(Enum):
+    FLAT = ('flat', -0.5)
+    FLAT_DOUBLE = ('double_flat', -1)
+    SHARP = ('sharp', 0.5)
+    SHARP_DOUBLE = ('double_sharp', 1)
+    NATURAL = ('natural', 0)
 
+    def __init__(self, acc_type: str, shift: float):
+        self.acc_type = acc_type
+        self.shift = shift
+
+    @staticmethod
+    def get_by_name(acc_type: str):
+        results = [val.acc_type for val in AccidentalTypes.__members__.values()]
+        if acc_type in results:
+            return results[0]
+        else:
+            raise ValueError(f'{acc_type} is not a valid Accidental type!')
+
+
+class Accidental:
     def __init__(self, x: int, y: int, template: Template, is_local: bool = True):
         self.x = x
         self.y = y
-        self.type = AccidentalTypes(template.name)
+        self.acc_type = AccidentalTypes.get_by_name(template.name)
         self.h = template.h
         self.w = template.w
 
-        self.pitch_change = self.pitch_change_dict[self.name]
         self.note = ''
         self.is_local = is_local
 
@@ -163,15 +181,6 @@ class Accidental:
 
     def set_is_local(self, is_local: bool):
         self.is_local = is_local
-
-
-@unique
-class AccidentalTypes(Enum):
-    FLAT = 'flat',
-    FLAT_DOUBLE = 'double_flat',
-    SHARP = 'sharp',
-    SHARP_DOUBLE = 'double_sharp',
-    NATURAL = 'natural'
 
 
 class Dots:

--- a/staffs/staff_objects.py
+++ b/staffs/staff_objects.py
@@ -9,6 +9,8 @@ import math
 
 import cv2
 
+from notes.note_objects import AccidentalTypes
+
 
 class Staff:
     def __init__(self, img_bar):
@@ -332,8 +334,8 @@ class Clef:
 class Key:
     def __init__(self, grouped_accidentals):
         self.x, self.y, self.h, self.w = self.find_rect(grouped_accidentals) if len(grouped_accidentals) > 0 else (
-        0, 0, 0, 0)
-        self.type = grouped_accidentals[0].type if len(grouped_accidentals) > 0 else 'normal'
+            0, 0, 0, 0)
+        self.acc_type = grouped_accidentals[0].type if len(grouped_accidentals) > 0 else 'normal'
         self.key = self.find_key(grouped_accidentals)
         self.accidentals = grouped_accidentals
 
@@ -351,9 +353,9 @@ class Key:
 
     def find_key(self, group):
         amount = len(group)
-        if self.type == 'flat':
+        if self.acc_type is AccidentalTypes.FLAT:
             return -1 * amount
-        elif self.type == 'sharp':
+        elif self.acc_type is AccidentalTypes.SHARP:
             return amount
         elif amount == 0:
             return 0

--- a/template_matching/template_matching.py
+++ b/template_matching/template_matching.py
@@ -81,11 +81,11 @@ class AvailableTemplates(Enum):
     AllClefs = [ClefG, ClefF, ClefC]
 
     # Keys
-    Flat = Template(AccidentalTypes.FLAT.value, 'images/templates/accidentals/flat.jpg', 2.4)
-    FlatDouble = Template(AccidentalTypes.FLAT_DOUBLE.value, 'images/templates/accidentals/double-flat.jpg', 2.4)
-    Sharp = Template(AccidentalTypes.SHARP.value, 'images/templates/accidentals/sharp.jpg', 2.8)
-    SharpDouble = Template(AccidentalTypes.SHARP_DOUBLE.value, 'images/templates/accidentals/double-sharp.jpg', 1)
-    Natural = Template(AccidentalTypes.NATURAL.value, 'images/templates/accidentals/natural.jpg', 3)
+    Flat = Template(AccidentalTypes.FLAT.acc_type, 'images/templates/accidentals/flat.jpg', 2.4)
+    FlatDouble = Template(AccidentalTypes.FLAT_DOUBLE.acc_type, 'images/templates/accidentals/double-flat.jpg', 2.4)
+    Sharp = Template(AccidentalTypes.SHARP.acc_type, 'images/templates/accidentals/sharp.jpg', 2.8)
+    SharpDouble = Template(AccidentalTypes.SHARP_DOUBLE.acc_type, 'images/templates/accidentals/double-sharp.jpg', 1)
+    Natural = Template(AccidentalTypes.NATURAL.acc_type, 'images/templates/accidentals/natural.jpg', 3)
 
     AllKeys = [Flat, FlatDouble, Sharp, SharpDouble, Natural]
 


### PR DESCRIPTION
add acc_type as attribute
add shift as attribute, making the extra dict obsolete
rename AccidentalType.type to AccidentalType.acc_type to prevent shadowing